### PR TITLE
Update templates to be compatible with Python 3

### DIFF
--- a/template/instance.jinja
+++ b/template/instance.jinja
@@ -33,12 +33,12 @@ resources:
          value: "us-central1"
       -  key: "replication-factor"
          value: "3"
-      {% for key, value in properties['metadata-from-file'].iteritems() %}
+      {% for key, value in properties['metadata-from-file'].items() %}
       - key: {{ key }}
         value: |
           {{ imports[value]|indent(10) }}
-    {% endfor %}
-      {% for key, value in properties['metadata'].iteritems() %}
+      {% endfor %}
+      {% for key, value in properties['metadata'].items() %}
       - key: {{ key }}
         value: {{ value }}
-    {% endfor %}
+      {% endfor %}


### PR DESCRIPTION
- Changes the occurrences of iteritems() to items()

It's possible that sometimes it will show this error, 
```
    The template produces different results with Python3 and Python2. This
    could be because of the non-determinism of your configuration, or a
    potential incompatibility with Python3. Make sure that your templates
    are compatible with
    Python3. https://cloud.google.com/deployment-manager/docs/migrate-to-python3
```
This is due to the fact that dictionaries are not ordered, so if we run the template twice (which GCP does to check compatibility with Python 2 and 3) it will have different order i.e. few metadata key values will have different order. It doesn't change the deployment in any way. 
I tried to run the same template around 5 to 6 times, that warning showed up only once.