### PR TITLE
Add default_memory_limit_to_ram_ratio flags to tserver and master

### DIFF
--- a/script/create_universe.sh
+++ b/script/create_universe.sh
@@ -55,6 +55,8 @@ echo "--master_addresses=${YB_MASTER_ADDRESSES}" >> ${YB_HOME}/master/conf/serve
 echo "--tserver_master_addrs=${YB_MASTER_ADDRESSES}" >> ${YB_HOME}/tserver/conf/server.conf
 echo "--replication_factor=${RF}" >> ${YB_HOME}/master/conf/server.conf
 echo "--replication_factor=${RF}" >> ${YB_HOME}/tserver/conf/server.conf
+echo "--default_memory_limit_to_ram_ratio=0.35" >> ${YB_HOME}/master/conf/server.conf
+echo "--default_memory_limit_to_ram_ratio=0.6" >> ${YB_HOME}/tserver/conf/server.conf
 
 ###############################################################################
 # Setup placement information if multi-AZ

--- a/template/instance.jinja
+++ b/template/instance.jinja
@@ -28,7 +28,7 @@ resources:
      metadata:
       items:
       -  key: "yb-version" 
-         value: "2.1.2.0" 
+         value: "2.1.4.0"
       -  key: "yb-region"
          value: "us-central1"
       -  key: "replication-factor"

--- a/template/instance.jinja
+++ b/template/instance.jinja
@@ -17,7 +17,7 @@ resources:
         initializeParams:
           diskName: boot
           sourceImage: https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7
-          diskSizeGb: 10
+          diskSizeGb: 20
       - deviceName: yb-disk
         type: PERSISTENT
         boot: flase


### PR DESCRIPTION
- Adds the flags to create_universe.sh
- New flag for master: `--default_memory_limit_to_ram_ratio=0.35`
- New flag for tserver: `--default_memory_limit_to_ram_ratio=0.6`
- Increase diskSizeGb as the new CentOS 7 images have image size of
  20GiB
- Update the version to 2.1.4

ref: yugabyte/yugabyte-db#4197